### PR TITLE
Uso de fechas UTC en el servicio de autenticación 

### DIFF
--- a/satxml
+++ b/satxml
@@ -64,8 +64,8 @@ function rfc {
 	fi
 }
 function autenticar {
-	DATESTART=`date -d '+6 hours' +%Y-%m-%dT%H:%M:00`
-	DATEEND=`date -d "+6 hours +$AUTTIME minutes" +%Y-%m-%dT%H:%M:00`
+	DATESTART=`date -u +%Y-%m-%dT%H:%M:00`
+	DATEEND=`date -u -d "+$AUTTIME minutes" +%Y-%m-%dT%H:%M:00`
 	DIGEST=$(sed "s/--DATESTART--/$DATESTART/g" ${XMLPATH}timestamp.xml | sed "s/--DATEEND--/$DATEEND/g" | openssl sha1 -binary | base64 | sed 's=/=\\\/=g')
 	sed "s/--DIGEST--/$DIGEST/" ${XMLPATH}signedinfo.xml | openssl dgst -sha1 -sign $KEY -out /tmp/sha1.sign -passin $KEYPASS 2>/dev/null
 	if [ $? -gt 0 ];then


### PR DESCRIPTION
La respuesta del servicio Web a la rutina de autenticar entrega el siguiente mensaje:
 
```
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode xmlns:a="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">a:InvalidSecurity</faultcode><faultstring xml:lang="en-US">An error occurred when verifying security for the message.</faultstring></s:Fault></s:Body></s:Envelope>
```
Revisando la rutina autenticar se observa que el desarrollador utiliza el formato de fecha de su zona horaria. Al cambiar el parámetro para utilizar la zona UTC el servicio Web valida y genera el token para las solicitudes subsecuentes.